### PR TITLE
Similar points render on top

### DIFF
--- a/geovibes/ui.py
+++ b/geovibes/ui.py
@@ -1572,7 +1572,10 @@ class GeoVibes:
             min_distance = search_results_filtered['distance'].min()
             max_distance = search_results_filtered['distance'].max()
             
-            for _, row in search_results_filtered.iterrows():
+            # Sort by distance in descending order so most similar (green) points render last and appear on top
+            search_results_sorted = search_results_filtered.sort_values('distance', ascending=False)
+            
+            for _, row in search_results_sorted.iterrows():
                 color = UIConstants.distance_to_color(row['distance'], min_distance, max_distance)
                 detections_geojson["features"].append({
                     "type": "Feature",


### PR DESCRIPTION
It was irking me that when zoomed out after a search, all I would see is a sea of red and I could not see where the most similar points were clustered (if clustered that is). I have tweaked the display to render the most similar points on top so you can see where they are located even when zoomed out:

<img width="1272" height="701" alt="image" src="https://github.com/user-attachments/assets/2f070530-80ed-47b7-b3bd-1dd503d0f6e4" />
