### PR TITLE
Ensure tile widgets are built on UI thread

### DIFF
--- a/tests/test_tile_panel.py
+++ b/tests/test_tile_panel.py
@@ -43,10 +43,11 @@ def test_tile_panel_update_results(monkeypatch):
         on_center=lambda row: None,
     )
 
-    def fake_widget(self, row, append):
+    def fake_widget(self, row, image_bytes):
         return Label(value=f"tile-{row['id']}")
 
-    monkeypatch.setattr(TilePanel, "_create_tile_widget", fake_widget)
+    monkeypatch.setattr(TilePanel, "_build_tile_widget", fake_widget)
+    monkeypatch.setattr(TilePanel, "_fetch_tile_image_bytes", lambda self, row: None)
 
     df = pd.DataFrame(
         [
@@ -149,7 +150,7 @@ def test_next_tiles_shows_loading_placeholders(monkeypatch):
 
     observed = {"placeholder_seen": False}
 
-    def fake_widget(self, row, append):
+    def fake_widget(self, row, image_bytes):
         if any(
             isinstance(child, VBox)
             and any(
@@ -161,7 +162,8 @@ def test_next_tiles_shows_loading_placeholders(monkeypatch):
             observed["placeholder_seen"] = True
         return Label(value=f"tile-{row['id']}")
 
-    monkeypatch.setattr(TilePanel, "_create_tile_widget", fake_widget)
+    monkeypatch.setattr(TilePanel, "_build_tile_widget", fake_widget)
+    monkeypatch.setattr(TilePanel, "_fetch_tile_image_bytes", lambda self, row: None)
 
     df = pd.DataFrame([{"id": str(i)} for i in range(8)])
 


### PR DESCRIPTION
### Summary
This PR refactors tile rendering to separate geometry parsing and map image fetching from UI widget creation, improving responsiveness and ensuring correct context propagation for ipywidgets.

### Details
- **Split tile rendering path**  
  Executor threads now handle geometry parsing and map byte fetching.  
  - `_fetch_tile_image_bytes` is responsible for WKT parsing and `get_map_image` calls.  
  - `_build_tile_widget` handles button, layout, and image assembly on the notebook (UI) thread.

- **Refactored page rendering**  
  `_render_current_page` now submits the fetch helper and later invokes `_on_tile_future_done` with row data and a captured `contextvars` snapshot.

- **Improved context handling**  
  `_on_tile_future_done` constructs widgets inside `_dispatch_to_ui`, which restores the captured `ContextVar` state so ipywidgets communications attach to the correct `shell_parent`.  
  Placeholder creation is now integrated into the same path for parity.

- **Enhanced UI dispatching**  
  `_dispatch_to_ui` accepts an optional context and executes the queued callback via the event loop or immediately, ensuring UI work always runs with the right kernel parent message.

- **Updated tests**  
  Tile-panel tests now monkeypatch the new helper methods to verify placeholder and pagination logic, as well as map image arguments—without instantiating actual widgets during unit tests.
