### PR TITLE
Add GEE tile layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ tile_panel_screenshot.png
 *.png
 preview_ui.sh
 alabama_aquaculture/
+
+# UI dev testing artifacts
+claude_ui_dev/

--- a/geovibes/ee_tools.py
+++ b/geovibes/ee_tools.py
@@ -18,13 +18,7 @@ def initialize_ee_with_credentials(verbose: bool = False) -> bool:
     except Exception as e:
         if verbose:
             print(f"❌ Earth Engine authentication failed: {e}")
-            print(
-                "\n🔧 To enable NDVI/NDWI basemaps, please run the following command:"
-            )
-            print("    earthengine authenticate")
-            print(
-                "⚠️  Continuing without Earth Engine (NDVI/NDWI basemaps will be unavailable)"
-            )
+            print("\n🔧 To enable Earth Engine layers, run: earthengine authenticate")
         return False
 
 

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -479,11 +479,6 @@ class GeoVibes:
         )
 
         # Export & Tools card (always visible)
-        # FileUpload widgets are placed in a hidden container to avoid gaps
-        self.hidden_uploads = VBox(
-            [self.file_upload, self.vector_file_upload],
-            layout=Layout(display="none"),
-        )
         export_card = v.Card(
             outlined=True,
             class_="section-card pa-3",
@@ -498,6 +493,7 @@ class GeoVibes:
                         self.load_btn,
                     ],
                 ),
+                self.file_upload,
                 v.BtnToggle(
                     v_model=None,
                     dense=True,
@@ -507,6 +503,7 @@ class GeoVibes:
                         self.google_maps_btn,
                     ],
                 ),
+                self.vector_file_upload,
             ],
         )
 
@@ -549,7 +546,6 @@ class GeoVibes:
                 self.detection_controls,
                 self.accordion_container,
                 self.reset_btn,
-                self.hidden_uploads,
             ],
             layout=Layout(
                 width=UIConstants.PANEL_WIDTH, padding="8px", overflow="hidden"

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import math
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -1232,6 +1232,7 @@ class GeoVibes:
         self.map_manager.clear_detection_layer()
         self.map_manager.clear_vector_layer()
         self.map_manager.clear_highlight()
+        self.map_manager.clear_overlay_layers()
         self.detection_controls.layout.display = "none"
         self.detection_status_label.value = ""
         # Reset slider and colormap range to defaults
@@ -1278,6 +1279,32 @@ class GeoVibes:
     @staticmethod
     def _empty_collection() -> Dict:
         return {"type": "FeatureCollection", "features": []}
+
+    # ------------------------------------------------------------------
+    # Overlay tile layer API
+    # ------------------------------------------------------------------
+
+    def add_tile_layer(self, url: str, name: str, opacity: float = 1.0) -> None:
+        """Add an XYZ tile layer overlay."""
+        self.map_manager.add_tile_layer(url, name, opacity)
+
+    def add_ee_layer(
+        self, ee_image, vis_params: Dict, name: str, opacity: float = 1.0
+    ) -> None:
+        """Add an Earth Engine image as a tile layer overlay."""
+        self.map_manager.add_ee_layer(ee_image, vis_params, name, opacity)
+
+    def remove_layer(self, name: str) -> bool:
+        """Remove an overlay layer by name."""
+        return self.map_manager.remove_layer(name)
+
+    def set_layer_opacity(self, name: str, opacity: float) -> None:
+        """Set the opacity of an overlay layer."""
+        self.map_manager.set_layer_opacity(name, opacity)
+
+    def list_layers(self) -> List[str]:
+        """Return names of all overlay layers."""
+        return self.map_manager.list_overlay_layers()
 
     def close(self) -> None:
         self.data.close()

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -367,7 +367,7 @@ class GeoVibes:
             ],
         )
 
-        # Detection controls (keep ipywidgets for sliders with text input)
+        # Detection controls (ipywidgets must be outside v.Card for proper rendering)
         self.detection_threshold_slider = FloatSlider(
             value=0.5,
             min=0.0,
@@ -375,33 +375,48 @@ class GeoVibes:
             step=0.01,
             description="",
             readout=False,
-            layout=Layout(width="100%", margin="0"),
+            layout=Layout(flex="1 1 auto", min_width="100px", margin="0"),
         )
         self.detection_threshold_text = FloatText(
             value=0.5,
             min=0.0,
             max=1.0,
             step=0.01,
-            layout=Layout(width="60px"),
+            layout=Layout(width="60px", flex="0 0 auto"),
         )
         self.detection_status_label = Label(
             value="",
-            layout=Layout(width="100%"),
+            layout=Layout(width="100%", margin="4px 0 0 0"),
         )
-        self.detection_controls = v.Card(
+        # Detection card with only the label (vuetify component)
+        detection_label_card = v.Card(
             outlined=True,
-            class_="section-card pa-3",
-            style_="display: none;",
+            class_="section-card pa-3 pb-1",
             children=[
                 v.Html(
-                    tag="span", class_="section-label", children=["DETECTION THRESHOLD"]
+                    tag="span",
+                    class_="section-label mb-0",
+                    children=["DETECTION THRESHOLD"],
                 ),
+            ],
+        )
+        # Detection widgets container (ipywidgets, placed outside v.Card)
+        self.detection_widgets_container = VBox(
+            [
                 HBox(
                     [self.detection_threshold_slider, self.detection_threshold_text],
-                    layout=Layout(align_items="center", width="100%"),
+                    layout=Layout(
+                        align_items="center", width="100%", display="flex", gap="8px"
+                    ),
                 ),
                 self.detection_status_label,
             ],
+            layout=Layout(width="100%", padding="0 12px", margin="0 0 8px 0"),
+        )
+        # Combined detection controls container
+        self.detection_controls = VBox(
+            [detection_label_card, self.detection_widgets_container],
+            layout=Layout(width="100%", display="none"),
         )
 
         # Database dropdown with ipyvuetify
@@ -775,7 +790,7 @@ class GeoVibes:
             self.dataset_manager.load_from_content(content, file_info["name"])
             if self.state.detection_mode:
                 # Show detection controls
-                self.detection_controls.style_ = "display: flex;"
+                self.detection_controls.layout.display = "flex"
                 features = self.state.detection_data.get("features", [])
                 num_detections = len(features)
 
@@ -802,7 +817,7 @@ class GeoVibes:
                 self._filter_detection_layer(self.detection_threshold_slider.value)
                 self._update_detection_tiles()
             else:
-                self.detection_controls.style_ = "display: none;"
+                self.detection_controls.layout.display = "none"
                 self._update_layers()
                 self._update_query_vector()
                 self._show_operation_status("✅ Dataset loaded")
@@ -1501,7 +1516,7 @@ class GeoVibes:
         self.map_manager.clear_vector_layer()
         self.map_manager.clear_highlight()
         self.map_manager.clear_overlay_layers()
-        self.detection_controls.style_ = "display: none;"
+        self.detection_controls.layout.display = "none"
         self.detection_status_label.value = ""
         # Reset slider and colormap range to defaults
         self.detection_threshold_slider.min = 0.0

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -1285,9 +1285,11 @@ class GeoVibes:
     # Overlay tile layer API
     # ------------------------------------------------------------------
 
-    def add_tile_layer(self, url: str, name: str, opacity: float = 1.0) -> None:
+    def add_tile_layer(
+        self, url: str, name: str, opacity: float = 1.0, attribution: str = ""
+    ) -> None:
         """Add an XYZ tile layer overlay."""
-        self.map_manager.add_tile_layer(url, name, opacity)
+        self.map_manager.add_tile_layer(url, name, opacity, attribution)
 
     def add_ee_layer(
         self, ee_image, vis_params: Dict, name: str, opacity: float = 1.0

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -115,6 +115,22 @@ SIDE_PANEL_CSS = """
     font-size: 12px !important;
     font-weight: 500 !important;
 }
+
+/* Compact FileUpload widget */
+.geovibes-panel .widget-upload {
+    padding: 0 !important;
+    margin: 4px 0 !important;
+}
+
+.geovibes-panel .widget-upload > .widget-label {
+    display: none !important;
+}
+
+.geovibes-panel .widget-upload-label {
+    font-size: 11px !important;
+    padding: 4px 8px !important;
+    margin: 0 !important;
+}
 </style>
 """
 
@@ -439,7 +455,7 @@ class GeoVibes:
         self.file_upload = FileUpload(
             accept=".geojson,.parquet",
             multiple=False,
-            layout=Layout(width="100%", display="none"),
+            layout=Layout(width="100%", display="none", margin="4px 0 0 0"),
         )
         self.add_vector_btn = v.Btn(
             small=True,
@@ -448,7 +464,7 @@ class GeoVibes:
         self.vector_file_upload = FileUpload(
             accept=".geojson,.parquet",
             multiple=False,
-            layout=Layout(width="100%", display="none"),
+            layout=Layout(width="100%", display="none", margin="4px 0 0 0"),
         )
         self.google_maps_btn = v.Btn(
             small=True,

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -495,6 +495,7 @@ class GeoVibes:
         )
 
         # Export & Tools card (always visible)
+        # FileUpload widgets are kept outside v.Card to avoid rendering issues
         export_card = v.Card(
             outlined=True,
             class_="section-card pa-3",
@@ -509,7 +510,6 @@ class GeoVibes:
                         self.load_btn,
                     ],
                 ),
-                self.file_upload,
                 v.BtnToggle(
                     v_model=None,
                     dense=True,
@@ -519,13 +519,26 @@ class GeoVibes:
                         self.google_maps_btn,
                     ],
                 ),
-                self.vector_file_upload,
             ],
+        )
+        # Container for file uploads (placed outside v.Card for proper rendering)
+        self.upload_container = VBox(
+            [self.file_upload, self.vector_file_upload],
+            layout=Layout(width="100%", padding="0 12px", margin="0"),
         )
 
         # Keep accordion_container reference for compatibility but not used
         self.accordion_container = VBox(
-            [w for w in [database_card, basemaps_card, export_card] if w is not None],
+            [
+                w
+                for w in [
+                    database_card,
+                    basemaps_card,
+                    export_card,
+                    self.upload_container,
+                ]
+                if w is not None
+            ],
             layout=Layout(width="100%"),
         )
 

--- a/geovibes/ui/app.py
+++ b/geovibes/ui/app.py
@@ -1472,7 +1472,7 @@ class GeoVibes:
         else:
             self._show_operation_status("⚠️ Nothing to save")
 
-    def reset_all(self, _button=None) -> None:
+    def reset_all(self, _button=None, clear_overlays: bool = False) -> None:
         if self.verbose:
             print("🗑️ Resetting all labels and search results...")
         self.state.reset()
@@ -1485,7 +1485,8 @@ class GeoVibes:
         self.map_manager.clear_detection_layer()
         self.map_manager.clear_vector_layer()
         self.map_manager.clear_highlight()
-        self.map_manager.clear_overlay_layers()
+        if clear_overlays:
+            self.map_manager.clear_overlay_layers()
         self.detection_controls.style_ = "display: none;"
         # Reset slider and colormap range to defaults
         self.detection_threshold_slider.min = 0.0

--- a/geovibes/ui/data_manager.py
+++ b/geovibes/ui/data_manager.py
@@ -9,10 +9,8 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 import duckdb
-import ee
 import faiss
 import geopandas as gpd
-import shapely.geometry
 
 from geovibes.ee_tools import initialize_ee_with_credentials
 from geovibes.ui_config import BasemapConfig, DatabaseConstants, GeoVibesConfig
@@ -49,7 +47,6 @@ class DataManager:
         self.baselayer_url = baselayer_url or BasemapConfig.BASEMAP_TILES["MAPTILER"]
         self.duckdb_path = duckdb_path
         self.duckdb_directory = duckdb_directory
-        self.ee_boundary = None
 
         if "enable_ee" in unused_kwargs and self.verbose:
             print(
@@ -142,7 +139,6 @@ class DataManager:
         self.effective_boundary_path, (self.center_y, self.center_x) = (
             self._setup_boundary_and_center()
         )
-        self._update_ee_boundary()
 
     # ------------------------------------------------------------------
     # Configuration helpers
@@ -674,22 +670,6 @@ class DataManager:
         )
         return None, (center_y, center_x)
 
-    def _update_ee_boundary(self) -> None:
-        if not self.ee_available:
-            return
-
-        if self.effective_boundary_path:
-            try:
-                boundary_gdf = gpd.read_file(self.effective_boundary_path)
-                geometry = shapely.geometry.mapping(boundary_gdf.union_all())
-                self.ee_boundary = ee.Geometry(geometry)
-            except Exception as exc:
-                if self.verbose:
-                    print(f"⚠️  Failed to update Earth Engine boundary: {exc}")
-                self.ee_boundary = None
-        else:
-            self.ee_boundary = None
-
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -817,7 +797,6 @@ class DataManager:
         self.effective_boundary_path, (self.center_y, self.center_x) = (
             self._setup_boundary_and_center()
         )
-        self._update_ee_boundary()
 
 
 __all__ = ["DataManager"]

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -385,61 +385,22 @@ class MapManager:
     def _build_layer_manager(self) -> ipyl.WidgetControl:
         style_css = HTML(
             """<style>
-            .layer-manager {
-                background: #ffffff;
-                border: 1px solid #e2e8f0;
-                border-radius: 6px;
-                box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-                font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-                padding: 6px 8px;
-            }
-            .layer-manager-header {
-                font-size: 11px;
-                font-weight: 600;
-                color: #374151;
-                margin-bottom: 4px;
-            }
-            .layer-row {
-                display: flex;
-                align-items: center;
-                gap: 6px;
-                margin: 2px 0;
-            }
-            .layer-row .widget-label {
-                font-size: 10px;
-                color: #64748b;
-                flex: 1;
-                min-width: 0;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-            .layer-row .widget-button {
-                min-width: 18px !important;
-                width: 18px !important;
-                height: 18px !important;
-                padding: 0 !important;
+            .layer-btn {
                 border-radius: 4px !important;
                 display: flex !important;
                 align-items: center !important;
                 justify-content: center !important;
-                line-height: 1 !important;
-            }
-            .layer-row .widget-button i {
-                font-size: 10px;
             }
             </style>"""
         )
         self._layer_rows = VBox(
-            [],
-            layout=Layout(max_height="150px", overflow_y="auto", overflow_x="hidden"),
+            [], layout=Layout(max_height="200px", overflow_y="auto")
         )
-        header = HTML('<div class="layer-manager-header">Layers</div>')
+        header = Label("Layers", style={"font_weight": "bold", "font_size": "12px"})
         self._layer_manager_container = VBox(
             [style_css, header, self._layer_rows],
-            layout=Layout(padding="0", width="180px"),
+            layout=Layout(padding="8px", min_width="180px"),
         )
-        self._layer_manager_container.add_class("layer-manager")
         control = ipyl.WidgetControl(
             widget=self._layer_manager_container,
             position="topleft",
@@ -458,13 +419,18 @@ class MapManager:
         self._layer_manager_container.layout.display = "flex" if rows else "none"
 
     def _create_layer_row(self, name: str, opacity: float) -> HBox:
-        label = Label(name)
+        label = Label(
+            name,
+            layout=Layout(width="90px", overflow="hidden"),
+            style={"font_size": "11px"},
+        )
         slider = FloatSlider(
             value=opacity,
             min=0,
             max=1,
             step=0.05,
             readout=False,
+            layout=Layout(width="70px"),
         )
 
         def on_opacity_change(change, layer_name=name):
@@ -473,16 +439,21 @@ class MapManager:
 
         slider.observe(on_opacity_change, names="value")
         remove_btn = Button(
-            icon="times", button_style="danger", tooltip=f"Remove {name}"
+            icon="times",
+            layout=Layout(width="24px", height="24px", padding="0"),
+            button_style="danger",
+            tooltip=f"Remove {name}",
         )
+        remove_btn.add_class("layer-btn")
 
         def on_remove(_, layer_name=name):
             self.remove_layer(layer_name)
 
         remove_btn.on_click(on_remove)
-        row = HBox([label, slider, remove_btn])
-        row.add_class("layer-row")
-        return row
+        return HBox(
+            [label, slider, remove_btn],
+            layout=Layout(margin="2px 0", align_items="center"),
+        )
 
     # ------------------------------------------------------------------
     # Overlay tile layer management

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -477,7 +477,10 @@ class MapManager:
             if lyr is self.basemap_layer:
                 basemap_idx = i
                 break
-        layers.insert(basemap_idx + 1, layer)
+        # Insert after basemap and all existing overlays (new layers appear on top)
+        # Note: layer is already in _overlay_layers when this is called
+        insert_idx = basemap_idx + len(self._overlay_layers)
+        layers.insert(insert_idx, layer)
         self.map.layers = tuple(layers)
 
 

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -415,6 +415,8 @@ class MapManager:
             self._layer_manager_container.hide()
 
     def _create_layer_row(self, name: str, opacity: float) -> v.Row:
+        display_name = name[:9] if len(name) > 9 else name
+
         slider = v.Slider(
             v_model=opacity,
             min=0,
@@ -423,7 +425,7 @@ class MapManager:
             hide_details=True,
             dense=True,
             class_="ma-0 pa-0",
-            style_="max-width: 60px;",
+            style_="flex: 1; min-width: 40px;",
         )
 
         def on_opacity_change(widget, event, data, layer_name=name):
@@ -437,7 +439,8 @@ class MapManager:
             x_small=True,
             children=[v.Icon(children=["mdi-close"], x_small=True)],
             color="error",
-            class_="ma-0",
+            class_="ma-0 pa-0",
+            style_="min-width: 20px; width: 20px;",
         )
 
         def on_remove(widget, event, data, layer_name=name):
@@ -449,9 +452,12 @@ class MapManager:
             children=[
                 v.Html(
                     tag="span",
-                    children=[name],
-                    class_="text-caption text-truncate",
-                    style_="max-width: 70px; flex-shrink: 0;",
+                    children=[display_name],
+                    class_="text-caption",
+                    style_=(
+                        "width: 54px; min-width: 54px; flex-shrink: 0; "
+                        "overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                    ),
                 ),
                 slider,
                 remove_btn,

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -426,7 +426,7 @@ class MapManager:
         header = HTML('<div class="layer-manager-header">Layers</div>')
         self._layer_manager_container = VBox(
             [style_css, header, self._layer_rows],
-            layout=Layout(padding="0"),
+            layout=Layout(padding="0", width="180px"),
         )
         self._layer_manager_container.add_class("layer-manager")
         control = ipyl.WidgetControl(

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -13,15 +13,7 @@ import shapely.geometry.base
 from ipyleaflet import DrawControl, Map
 import ipyvuetify as v
 from ipywidgets import HTML, HBox, Layout, VBox
-from tqdm import tqdm
-
-from geovibes.ee_tools import (
-    get_ee_image_url,
-    get_s2_hsv_median,
-    get_s2_ndvi_median,
-    get_s2_ndwi_median,
-    get_s2_rgb_median,
-)
+from geovibes.ee_tools import get_ee_image_url
 from geovibes.ui_config import BasemapConfig, LayerStyles, UIConstants
 
 from .status import StatusBus
@@ -70,57 +62,7 @@ class MapManager:
     # ------------------------------------------------------------------
 
     def _setup_basemap_tiles(self) -> Dict[str, str]:
-        basemap_tiles = BasemapConfig.BASEMAP_TILES.copy()
-        # TODO: Re-enable EE basemaps after testing tile layers
-        if False and self.data.ee_available:
-            try:
-                if self.verbose:
-                    print(
-                        "🛰️ Setting up Earth Engine basemaps (S2 RGB, NDVI, NDWI, HSV)..."
-                    )
-
-                boundary = self.data.ee_boundary
-                start = self.data.config.start_date
-                end = self.data.config.end_date
-
-                basemap_tasks = [
-                    (
-                        "S2_RGB",
-                        lambda: get_s2_rgb_median(boundary, start, end),
-                        BasemapConfig.S2_RGB_VIS_PARAMS,
-                    ),
-                    (
-                        "S2_NDVI",
-                        lambda: get_s2_ndvi_median(boundary, start, end),
-                        BasemapConfig.NDVI_VIS_PARAMS,
-                    ),
-                    (
-                        "S2_NDWI",
-                        lambda: get_s2_ndwi_median(boundary, start, end),
-                        BasemapConfig.NDWI_VIS_PARAMS,
-                    ),
-                    (
-                        "S2_HSV",
-                        lambda: get_s2_hsv_median(boundary, start, end),
-                        BasemapConfig.S2_HSV_VIS_PARAMS,
-                    ),
-                ]
-
-                for name, image_func, vis_params in tqdm(
-                    basemap_tasks, desc="Loading Earth Engine basemaps"
-                ):
-                    image = image_func()
-                    basemap_tiles[name] = get_ee_image_url(image, vis_params)
-
-                if self.verbose:
-                    print("✅ Earth Engine basemaps added successfully!")
-            except Exception as exc:
-                if self.verbose:
-                    print(f"⚠️  Failed to create Earth Engine basemaps: {exc}")
-                    print("⚠️  Continuing with basic basemaps only")
-        elif self.verbose:
-            print("⚠️  Earth Engine not available - S2/NDVI/NDWI basemaps skipped")
-        return basemap_tiles
+        return BasemapConfig.BASEMAP_TILES.copy()
 
     def _build_map(self, center) -> Map:
         map_widget = Map(

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -391,45 +391,37 @@ class MapManager:
                 border-radius: 6px;
                 box-shadow: 0 1px 3px rgba(0,0,0,0.08);
                 font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-                padding: 8px 10px;
-                min-width: 190px;
+                padding: 6px 8px;
             }
             .layer-manager-header {
                 font-size: 11px;
                 font-weight: 600;
                 color: #374151;
-                margin-bottom: 6px;
-                letter-spacing: 0.3px;
+                margin-bottom: 4px;
             }
             .layer-row {
                 display: flex;
                 align-items: center;
-                gap: 6px;
-                margin: 4px 0;
+                gap: 4px;
+                margin: 2px 0;
             }
             .layer-row .widget-label {
-                font-size: 11px;
+                font-size: 10px;
                 color: #64748b;
-                width: 80px;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-            .layer-row .widget-floatslider {
-                width: 70px;
             }
             .layer-row .widget-button {
-                min-width: 22px !important;
-                width: 22px !important;
-                height: 22px !important;
+                min-width: 18px !important;
+                width: 18px !important;
+                height: 18px !important;
                 padding: 0 !important;
-                font-size: 10px;
+                font-size: 9px;
+                border-radius: 4px !important;
             }
             </style>"""
         )
         self._layer_rows = VBox(
             [],
-            layout=Layout(max_height="200px", overflow_y="auto", overflow_x="hidden"),
+            layout=Layout(max_height="150px", overflow_y="auto", overflow_x="hidden"),
         )
         header = HTML('<div class="layer-manager-header">Layers</div>')
         self._layer_manager_container = VBox(
@@ -439,7 +431,7 @@ class MapManager:
         self._layer_manager_container.add_class("layer-manager")
         control = ipyl.WidgetControl(
             widget=self._layer_manager_container,
-            position="topright",
+            position="topleft",
         )
         self._layer_manager_container.layout.display = "none"
         self.map.add_control(control)

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -402,20 +402,31 @@ class MapManager:
             .layer-row {
                 display: flex;
                 align-items: center;
-                gap: 4px;
+                gap: 6px;
                 margin: 2px 0;
             }
             .layer-row .widget-label {
                 font-size: 10px;
                 color: #64748b;
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
             .layer-row .widget-button {
                 min-width: 18px !important;
                 width: 18px !important;
                 height: 18px !important;
                 padding: 0 !important;
-                font-size: 9px;
                 border-radius: 4px !important;
+                display: flex !important;
+                align-items: center !important;
+                justify-content: center !important;
+                line-height: 1 !important;
+            }
+            .layer-row .widget-button i {
+                font-size: 10px;
             }
             </style>"""
         )

--- a/geovibes/ui/map_manager.py
+++ b/geovibes/ui/map_manager.py
@@ -421,7 +421,7 @@ class MapManager:
         attribution: str = "",
     ) -> None:
         if name in self._overlay_layers:
-            raise ValueError(f"Layer '{name}' already exists")
+            self.remove_layer(name)
         opacity = max(0.0, min(1.0, opacity))
         layer = ipyl.TileLayer(
             url=url,

--- a/geovibes/ui_config/constants.py
+++ b/geovibes/ui_config/constants.py
@@ -58,7 +58,7 @@ class UIConstants:
     NEGATIVE_LABEL = 0
     ERASE_LABEL = -100
 
-    SEARCH_COLORMAP = os.getenv("GEOVIBES_SEARCH_COLORMAP", "plasma")
+    SEARCH_COLORMAP = os.getenv("GEOVIBES_SEARCH_COLORMAP", "turbo")
     _COLORMAP_CACHE: dict[str, dict[str, object]] = {}
 
     @classmethod

--- a/geovibes/ui_config/constants.py
+++ b/geovibes/ui_config/constants.py
@@ -200,15 +200,6 @@ class BasemapConfig:
         "GOOGLE_HYBRID": "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
     }
 
-    # Earth Engine basemap visualization parameters
-    S2_RGB_VIS_PARAMS = {"min": 0, "max": 3000, "bands": ["B4", "B3", "B2"]}
-
-    NDVI_VIS_PARAMS = {"min": -0.1, "max": 1.0, "palette": ["red", "yellow", "green"]}
-
-    NDWI_VIS_PARAMS = {"min": -0.5, "max": 0.5, "palette": ["brown", "white", "blue"]}
-
-    S2_HSV_VIS_PARAMS = {"min": 0, "max": 1, "bands": ["hue", "saturation", "value"]}
-
 
 class DatabaseConstants:
     """Database-related constants."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "voila",
     "playwright>=1.56.0",
     "xgboost>=2.0.0",
+    "ipyvuetify>=1.11.3",
 ]
 
 

--- a/scripts/export_cdl_mask.py
+++ b/scripts/export_cdl_mask.py
@@ -1,0 +1,195 @@
+"""Export CDL aquaculture/water mask to GeoTIFF via Earth Engine.
+
+Takes detection polygons, buffers them, intersects with CDL water classes,
+applies morphological closing, and exports to Google Drive.
+"""
+
+import argparse
+import json
+import time
+
+import ee
+import geopandas as gpd
+
+
+def load_geojson_to_ee(geojson_path: str, buffer_m: float) -> ee.Geometry:
+    """Load GeoJSON polygons, buffer, and convert to EE geometry."""
+    start = time.perf_counter()
+
+    gdf = gpd.read_file(geojson_path)
+    print(f"  Loaded {len(gdf)} features from {geojson_path}")
+
+    # Buffer in a projected CRS (UTM zone estimated from centroid)
+    centroid = gdf.union_all().centroid
+    utm_zone = int((centroid.x + 180) / 6) + 1
+    utm_crs = (
+        f"EPSG:326{utm_zone:02d}" if centroid.y >= 0 else f"EPSG:327{utm_zone:02d}"
+    )
+
+    gdf_utm = gdf.to_crs(utm_crs)
+    gdf_buffered = gdf_utm.buffer(buffer_m)
+    gdf_buffered_wgs84 = gpd.GeoSeries(gdf_buffered, crs=utm_crs).to_crs("EPSG:4326")
+
+    # Union all geometries
+    union_geom = gdf_buffered_wgs84.union_all()
+
+    # Convert to EE geometry
+    geojson_dict = json.loads(gpd.GeoSeries([union_geom]).to_json())
+    ee_geom = ee.Geometry(geojson_dict["features"][0]["geometry"])
+
+    elapsed = time.perf_counter() - start
+    print(f"  Buffered by {buffer_m}m and converted to EE geometry ({elapsed:.2f}s)")
+
+    return ee_geom
+
+
+def create_cdl_water_mask(year: int) -> ee.Image:
+    """Create binary mask for CDL aquaculture (92) and open water (111)."""
+    start = time.perf_counter()
+
+    cdl = (
+        ee.ImageCollection("USDA/NASS/CDL")
+        .filterDate(f"{year}-01-01", f"{year}-12-31")
+        .first()
+        .select("cropland")
+    )
+
+    # Binary mask: Aquaculture (92) OR Open Water (111)
+    water_mask = cdl.eq(92).Or(cdl.eq(111))
+
+    elapsed = time.perf_counter() - start
+    print(f"  Created CDL water mask for {year} ({elapsed:.2f}s)")
+
+    return water_mask
+
+
+def apply_morphological_closing(mask: ee.Image, radius: int = 1) -> ee.Image:
+    """Apply morphological closing (dilation then erosion)."""
+    start = time.perf_counter()
+
+    closed = mask.focal_max(
+        radius=radius, kernelType="square", units="pixels"
+    ).focal_min(radius=radius, kernelType="square", units="pixels")
+
+    elapsed = time.perf_counter() - start
+    print(
+        f"  Applied morphological closing with {2*radius+1}x{2*radius+1} kernel ({elapsed:.2f}s)"
+    )
+
+    return closed
+
+
+def export_to_drive(
+    image: ee.Image,
+    region: ee.Geometry,
+    output_name: str,
+    scale: int = 30,
+    folder: str = "earth_engine_exports",
+) -> ee.batch.Task:
+    """Export image to Google Drive as GeoTIFF."""
+    start = time.perf_counter()
+
+    # Cast to byte (0/1 values)
+    image_byte = image.toByte()
+
+    task = ee.batch.Export.image.toDrive(
+        image=image_byte,
+        description=output_name,
+        folder=folder,
+        fileNamePrefix=output_name,
+        region=region,
+        scale=scale,
+        crs="EPSG:4326",
+        maxPixels=1e13,
+        fileFormat="GeoTIFF",
+    )
+
+    task.start()
+
+    elapsed = time.perf_counter() - start
+    print(f"  Started export task '{output_name}' ({elapsed:.2f}s)")
+
+    return task
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export CDL aquaculture/water mask to GeoTIFF"
+    )
+    parser.add_argument(
+        "--geojson",
+        required=True,
+        help="Path to detection GeoJSON (polygons)",
+    )
+    parser.add_argument(
+        "--output-name",
+        required=True,
+        help="Name for the export (used in Drive filename)",
+    )
+    parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=160,
+        help="Buffer distance in meters (default: 160)",
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=2023,
+        help="CDL year to use (default: 2023)",
+    )
+    parser.add_argument(
+        "--folder",
+        default="earth_engine_exports",
+        help="Google Drive folder for export (default: earth_engine_exports)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print info without starting export",
+    )
+
+    args = parser.parse_args()
+
+    print("Initializing Earth Engine...")
+    ee.Initialize()
+
+    print("\n1. Loading and buffering detections...")
+    region = load_geojson_to_ee(args.geojson, args.buffer_m)
+
+    print("\n2. Creating CDL water mask...")
+    water_mask = create_cdl_water_mask(args.year)
+
+    print("\n3. Applying morphological closing...")
+    closed_mask = apply_morphological_closing(water_mask, radius=1)
+
+    # Clip to region
+    clipped_mask = closed_mask.clip(region)
+
+    if args.dry_run:
+        print("\n[DRY RUN] Would export to Drive:")
+        print(f"  Output name: {args.output_name}")
+        print(f"  Folder: {args.folder}")
+        print("  Scale: 30m")
+        return
+
+    print("\n4. Exporting to Google Drive...")
+    task = export_to_drive(
+        clipped_mask,
+        region,
+        args.output_name,
+        scale=30,
+        folder=args.folder,
+    )
+
+    print("\n✅ Export task started!")
+    print(f"   Task ID: {task.id}")
+    print(f"   Status: {task.status()['state']}")
+    print("   Monitor at: https://code.earthengine.google.com/tasks")
+    print(
+        f"\n   Output will appear in Google Drive folder: {args.folder}/{args.output_name}.tif"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overlay_detections_on_image.py
+++ b/scripts/overlay_detections_on_image.py
@@ -1,0 +1,265 @@
+"""Overlay GeoJSON detections on a georeferenced map image.
+
+This script takes a map image and overlays detection polygons by
+mapping geographic coordinates to pixel coordinates.
+"""
+
+import argparse
+from pathlib import Path
+
+import geopandas as gpd
+from PIL import Image, ImageDraw, ImageFont
+
+
+def geo_to_pixel(
+    lon: float,
+    lat: float,
+    geo_bounds: tuple,
+    pixel_bounds: tuple,
+) -> tuple:
+    """Convert geographic coordinates to pixel coordinates.
+
+    Args:
+        lon: Longitude
+        lat: Latitude
+        geo_bounds: (min_lon, min_lat, max_lon, max_lat)
+        pixel_bounds: (left, top, right, bottom) in pixels
+
+    Returns:
+        (x, y) pixel coordinates
+    """
+    min_lon, min_lat, max_lon, max_lat = geo_bounds
+    px_left, px_top, px_right, px_bottom = pixel_bounds
+
+    # Normalize to 0-1
+    x_norm = (lon - min_lon) / (max_lon - min_lon)
+    y_norm = (lat - min_lat) / (max_lat - min_lat)
+
+    # Convert to pixels (y is inverted in images)
+    px_x = px_left + x_norm * (px_right - px_left)
+    px_y = px_bottom - y_norm * (px_bottom - px_top)
+
+    return px_x, px_y
+
+
+def polygon_to_pixels(geom, geo_bounds, pixel_bounds) -> list:
+    """Convert a polygon geometry to pixel coordinates."""
+    if geom.geom_type == "Polygon":
+        coords = list(geom.exterior.coords)
+        return [geo_to_pixel(lon, lat, geo_bounds, pixel_bounds) for lon, lat in coords]
+    elif geom.geom_type == "MultiPolygon":
+        all_coords = []
+        for poly in geom.geoms:
+            coords = list(poly.exterior.coords)
+            all_coords.append(
+                [
+                    geo_to_pixel(lon, lat, geo_bounds, pixel_bounds)
+                    for lon, lat in coords
+                ]
+            )
+        return all_coords
+    return []
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Overlay GeoJSON detections on a map image"
+    )
+    parser.add_argument(
+        "--image",
+        required=True,
+        help="Path to the map image",
+    )
+    parser.add_argument(
+        "--geojson",
+        required=True,
+        help="Path to detection GeoJSON",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output image path",
+    )
+    parser.add_argument(
+        "--label",
+        default=None,
+        help="Label text to add to the image",
+    )
+    parser.add_argument(
+        "--geo-bounds",
+        nargs=4,
+        type=float,
+        default=[-88.473227, 30.144425, -84.888246, 35.008028],
+        metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
+        help="Geographic bounds of the map area",
+    )
+    parser.add_argument(
+        "--pixel-bounds",
+        nargs=4,
+        type=int,
+        default=None,
+        metavar=("LEFT", "TOP", "RIGHT", "BOTTOM"),
+        help="Pixel bounds of the map area (auto-detect if not provided)",
+    )
+    parser.add_argument(
+        "--color",
+        default="red",
+        help="Color for detection outlines (default: red)",
+    )
+    parser.add_argument(
+        "--fill-alpha",
+        type=int,
+        default=80,
+        help="Fill transparency 0-255 (default: 80)",
+    )
+    parser.add_argument(
+        "--line-width",
+        type=int,
+        default=2,
+        help="Outline width in pixels (default: 2)",
+    )
+    parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=0,
+        help="Buffer geometries by this many meters before plotting (default: 0)",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Loading image: {args.image}")
+    img = Image.open(args.image).convert("RGBA")
+    img_width, img_height = img.size
+    print(f"  Image size: {img_width} x {img_height}")
+
+    # Pixel bounds for the Alabama soil map
+    # These were measured manually from the image
+    # The map area (excluding title, legend, scale bar)
+    if args.pixel_bounds:
+        pixel_bounds = tuple(args.pixel_bounds)
+    else:
+        # Default bounds for the USDA 1993 Alabama Soil Map
+        # Measured from the image: map starts around x=47, ends around x=598
+        # y starts around 38, ends around 789
+        pixel_bounds = (47, 38, 598, 789)
+        print(f"  Using default pixel bounds for Alabama soil map: {pixel_bounds}")
+
+    geo_bounds = tuple(args.geo_bounds)
+    print(f"  Geographic bounds: {geo_bounds}")
+
+    print(f"\nLoading detections: {args.geojson}")
+    detections = gpd.read_file(args.geojson)
+    print(f"  Loaded {len(detections)} features")
+
+    # Buffer geometries if requested
+    if args.buffer_m > 0:
+        print(f"  Buffering by {args.buffer_m}m...")
+        # Project to UTM for accurate buffering
+        centroid = detections.union_all().centroid
+        utm_zone = int((centroid.x + 180) / 6) + 1
+        utm_crs = (
+            f"EPSG:326{utm_zone:02d}" if centroid.y >= 0 else f"EPSG:327{utm_zone:02d}"
+        )
+        detections = detections.to_crs(utm_crs)
+        detections["geometry"] = detections.geometry.buffer(args.buffer_m)
+        detections = detections.to_crs("EPSG:4326")
+
+    # Create overlay layer with transparency
+    overlay = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+
+    # Parse color
+    from PIL import ImageColor
+
+    try:
+        rgb = ImageColor.getrgb(args.color)
+    except ValueError:
+        rgb = (255, 0, 0)  # Default to red
+
+    fill_color = (*rgb, args.fill_alpha)
+    outline_color = (*rgb, 255)
+
+    print(f"\nDrawing {len(detections)} detection polygons...")
+    for idx, row in detections.iterrows():
+        geom = row.geometry
+        if geom is None:
+            continue
+
+        if geom.geom_type == "Polygon":
+            pixel_coords = polygon_to_pixels(geom, geo_bounds, pixel_bounds)
+            if pixel_coords:
+                draw.polygon(
+                    pixel_coords,
+                    fill=fill_color,
+                    outline=outline_color,
+                    width=args.line_width,
+                )
+        elif geom.geom_type == "MultiPolygon":
+            for poly in geom.geoms:
+                coords = list(poly.exterior.coords)
+                pixel_coords = [
+                    geo_to_pixel(lon, lat, geo_bounds, pixel_bounds)
+                    for lon, lat in coords
+                ]
+                if pixel_coords:
+                    draw.polygon(
+                        pixel_coords,
+                        fill=fill_color,
+                        outline=outline_color,
+                        width=args.line_width,
+                    )
+        elif geom.geom_type == "Point":
+            px, py = geo_to_pixel(geom.x, geom.y, geo_bounds, pixel_bounds)
+            r = 4
+            draw.ellipse(
+                [px - r, py - r, px + r, py + r], fill=fill_color, outline=outline_color
+            )
+
+    # Composite overlay onto image
+    result = Image.alpha_composite(img, overlay)
+
+    # Add legend entry for detections (below existing soil legend)
+    if args.label:
+        draw_result = ImageDraw.Draw(result)
+        # Try to use a nice font, fall back to default
+        try:
+            font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 11)
+        except OSError:
+            font = ImageFont.load_default()
+
+        # Position below the existing soil legend entries
+        # Matching the style of existing legend: colored box on left, text on right
+        # Legend entries: Limestone Valley, Appalachian Plateau, Piedmont Plateau,
+        # Blackland Prairie, Coastal Plain, Major Flood Plain, Coastal Marsh and Beach
+        legend_x = 695  # X position for legend box (aligned with existing boxes)
+        legend_y = 345  # Y position below COASTAL MARSH AND BEACH (the last entry)
+        box_width = 30
+        box_height = 16
+        text_offset = 36
+
+        # Draw legend box with detection color (matching existing box style)
+        draw_result.rectangle(
+            [legend_x, legend_y, legend_x + box_width, legend_y + box_height],
+            fill=(*rgb, 220),
+            outline=(0, 0, 0),
+            width=1,
+        )
+
+        # Draw legend text
+        draw_result.text(
+            (legend_x + text_offset, legend_y + 2),
+            args.label.upper(),
+            fill=(0, 0, 0),
+            font=font,
+        )
+
+    # Save result
+    output_path = Path(args.output)
+    if output_path.suffix.lower() in [".jpg", ".jpeg"]:
+        result = result.convert("RGB")
+    result.save(args.output)
+    print(f"\nSaved: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_manager_boundary.py
+++ b/tests/test_data_manager_boundary.py
@@ -1,68 +1,12 @@
-import geopandas as gpd
-import shapely.geometry
-from shapely.geometry import shape
-
 import faiss
 
-import geovibes.ui.data_manager as data_manager_module
 from geovibes.ui.data_manager import DataManager
 
 
-def test_update_ee_boundary_uses_current_geometry(monkeypatch):
-    dm = DataManager.__new__(DataManager)
-    dm.ee_available = True
-    dm.verbose = False
-
-    polygon_a = shapely.geometry.box(0, 0, 1, 1)
-    polygon_b = shapely.geometry.box(1, 1, 2, 2)
-    gdf_a = gpd.GeoDataFrame({"geometry": [polygon_a]})
-    gdf_b = gpd.GeoDataFrame({"geometry": [polygon_b]})
-
-    geometries = {
-        "first.geojson": gdf_a,
-        "second.geojson": gdf_b,
-    }
-
-    monkeypatch.setattr(
-        data_manager_module.gpd, "read_file", lambda path: geometries[path]
-    )
-
-    recorded = []
-
-    def fake_geometry(mapping):
-        recorded.append(mapping)
-        return mapping
-
-    monkeypatch.setattr(data_manager_module.ee, "Geometry", fake_geometry)
-
-    dm.effective_boundary_path = "first.geojson"
-    dm._update_ee_boundary()
-    first_shape = shape(dm.ee_boundary)
-    assert first_shape.equals(polygon_a)
-
-    dm.effective_boundary_path = "second.geojson"
-    dm._update_ee_boundary()
-    second_shape = shape(dm.ee_boundary)
-    assert second_shape.equals(polygon_b)
-    assert len(recorded) == 2
-
-
-def test_update_ee_boundary_skips_when_disabled(monkeypatch):
-    dm = DataManager.__new__(DataManager)
-    dm.ee_available = False
-    dm.effective_boundary_path = "first.geojson"
-    dm.ee_boundary = "existing"
-
-    dm._update_ee_boundary()
-
-    assert dm.ee_boundary == "existing"
-
-
-def test_switch_database_invokes_boundary_refresh(monkeypatch):
+def test_switch_database_updates_boundary_path(monkeypatch):
     dm = DataManager.__new__(DataManager)
     dm.verbose = False
     dm.ee_available = True
-    dm.ee_boundary = None
     dm.current_database_path = "db1"
     dm.current_database_info = {"faiss_path": "index1", "geometry_path": "geom1"}
     dm.current_faiss_path = "index1"
@@ -86,16 +30,8 @@ def test_switch_database_invokes_boundary_refresh(monkeypatch):
         DataManager, "_setup_boundary_and_center", fake_setup_boundary_and_center
     )
 
-    calls = []
-
-    def fake_update(self):
-        calls.append(True)
-
-    monkeypatch.setattr(DataManager, "_update_ee_boundary", fake_update)
-
     dm.switch_database("db2")
 
     assert dm.current_database_path == "db2"
     assert dm.current_geometry_path == "geom2"
     assert dm.effective_boundary_path == "geom2"
-    assert calls, "_update_ee_boundary was not invoked"

--- a/tests/test_map_manager_unit.py
+++ b/tests/test_map_manager_unit.py
@@ -351,6 +351,46 @@ def test_create_layer_row_preserves_short_names():
     assert label.children[0] == "LULC2024"
 
 
+def test_ipyvuetify_show_hide_methods():
+    """Verify ipyvuetify widgets have working show/hide methods."""
+    import ipyvuetify as v
+
+    card = v.Card()
+    assert hasattr(card, "show")
+    assert hasattr(card, "hide")
+
+    card.hide()
+    assert "d-none" in card.class_
+
+    card.show()
+    assert "d-none" not in (card.class_ or "")
+
+
+def test_layer_manager_visibility_toggle():
+    """Test that layer manager container visibility is properly toggled."""
+    manager = MapManager.__new__(MapManager)
+    manager._overlay_layers = {}
+
+    manager._layer_rows = MagicMock()
+    manager._layer_rows.children = []
+
+    import ipyvuetify as v
+
+    manager._layer_manager_container = v.Card()
+    manager._create_layer_row = lambda name, opacity: MagicMock()
+
+    manager._layer_manager_container.hide()
+    assert "d-none" in manager._layer_manager_container.class_
+
+    manager._overlay_layers = {"test": MagicMock(opacity=0.5)}
+    manager._refresh_layer_manager()
+    assert "d-none" not in (manager._layer_manager_container.class_ or "")
+
+    manager._overlay_layers = {}
+    manager._refresh_layer_manager()
+    assert "d-none" in manager._layer_manager_container.class_
+
+
 # ------------------------------------------------------------------
 # Basemap tests
 # ------------------------------------------------------------------

--- a/tests/test_polygon_labeling.py
+++ b/tests/test_polygon_labeling.py
@@ -67,6 +67,10 @@ def geo_vibes_stub():
     gv.tile_panel = DummyTilePanel()
     gv.tiles_button = SimpleNamespace(button_style="")
 
+    # Add label/mode values used by toggle change handlers
+    gv._label_values = ["Positive", "Negative", "Erase"]
+    gv._mode_values = ["point", "polygon"]
+
     # Replace heavy operations with no-ops for isolated testing
     gv._show_operation_status = lambda *args, **kwargs: None
     gv._update_status = lambda *args, **kwargs: None
@@ -159,11 +163,12 @@ def test_polygon_mode_disables_point_labeling(geo_vibes_stub):
 
     gv.label_point = fake_label_point
 
-    gv._on_selection_mode_change({"new": "polygon"})
+    # _mode_values = ["point", "polygon"], so index 1 = polygon, index 0 = point
+    gv._on_selection_mode_change({"new": 1})  # polygon mode
     gv._on_map_interaction(type="click", coordinates=(37.0, -1.0), modifiers={})
     assert called["value"] is False
 
-    gv._on_selection_mode_change({"new": "point"})
+    gv._on_selection_mode_change({"new": 0})  # point mode
     gv._on_map_interaction(type="click", coordinates=(37.0, -1.0), modifiers={})
     assert called["value"] is True
 
@@ -194,7 +199,8 @@ def test_iterative_label_workflow_positive_then_negative(geo_vibes_stub):
     assert layer_calls[-1] == (["1"], [])
     assert query_calls[-1] == ("1",)
 
-    gv._on_label_change({"new": "Negative"})
+    # _label_values = ["Positive", "Negative", "Erase"], so index 1 = Negative
+    gv._on_label_toggle_change({"new": 1})
     assert gv.state.current_label == "Negative"
 
     gv.label_point(lon=-1.2, lat=37.2)
@@ -221,7 +227,8 @@ def test_relabel_point_from_positive_to_negative(geo_vibes_stub):
     assert gv.state.pos_ids == ["7"]
     assert gv.state.neg_ids == []
 
-    gv._on_label_change({"new": "Negative"})
+    # _label_values = ["Positive", "Negative", "Erase"], so index 1 = Negative
+    gv._on_label_toggle_change({"new": 1})
     gv.label_point(lon=-1.0, lat=37.0)
 
     assert gv.state.pos_ids == []

--- a/uv.lock
+++ b/uv.lock
@@ -1610,6 +1610,7 @@ dependencies = [
     { name = "ipyleaflet" },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipyvuetify" },
     { name = "ipywidgets" },
     { name = "joblib" },
     { name = "jupyterlab" },
@@ -1652,6 +1653,7 @@ requires-dist = [
     { name = "ipykernel" },
     { name = "ipyleaflet" },
     { name = "ipython" },
+    { name = "ipyvuetify", specifier = ">=1.11.3" },
     { name = "ipywidgets" },
     { name = "joblib" },
     { name = "jupyterlab" },
@@ -2157,6 +2159,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipyvue"
+version = "1.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipywidgets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6c/01b55711d120dcc9e31e2c514671fe0d6932e6fd402871d18fd034220da5/ipyvue-1.11.3.tar.gz", hash = "sha256:80b3b6108b448eb17b7c9eb0c39b5ad384718abdcd24a82f853ad3062b83b41b", size = 1744625, upload-time = "2025-09-10T11:18:59.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f4/93c187f69bbd58669d315f5463124ef62484a24335bc6702d19c83d1311e/ipyvue-1.11.3-py2.py3-none-any.whl", hash = "sha256:f6f4680a8b61c190dd56a461b5c595d05d84699dde2f7dd5c43f5db7520c6028", size = 2670770, upload-time = "2025-09-10T11:18:57.951Z" },
+]
+
+[[package]]
+name = "ipyvuetify"
+version = "1.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipyvue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/07/31c9615532b6c190a3033460e4aa83a64ac532281758ff734e1bc42e3c00/ipyvuetify-1.11.3.tar.gz", hash = "sha256:3580afa76d9add4ae04ccb7fd57d4a0cf03a261705742e7137def3ebb65ac71d", size = 6170730, upload-time = "2025-07-02T11:25:12.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/4d/fd1a6a888f8abb6b8dc316cc78b5153e75eff7ae66a94cf30b144fadd09d/ipyvuetify-1.11.3-py2.py3-none-any.whl", hash = "sha256:fa83aaf9f4ce669172d532094d60bd7c40d3cb9c5d6bb2f4a14565da2b09a8d8", size = 6290266, upload-time = "2025-07-02T11:25:10.553Z" },
 ]
 
 [[package]]

--- a/vibe_checker.ipynb
+++ b/vibe_checker.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -17,7 +17,7 @@
       "text/html": [
        "<p>To authorize access needed by Earth Engine, open the following\n",
        "        URL in a web browser and follow the instructions:</p>\n",
-       "        <p><a href=https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=uqZS-obTBxnmg7z2DSMTBW4QKt-rU6H3qWB9ixCJf-4&tc=bSmOSLqACwNnJB19C-pQI7uCAfB6mzr3LTMy1m4DR7U&cc=XvXPiiDrDCyVg5wgPHGd-zVWtM1HR-WLYBLY6p7JWZ0>https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=uqZS-obTBxnmg7z2DSMTBW4QKt-rU6H3qWB9ixCJf-4&tc=bSmOSLqACwNnJB19C-pQI7uCAfB6mzr3LTMy1m4DR7U&cc=XvXPiiDrDCyVg5wgPHGd-zVWtM1HR-WLYBLY6p7JWZ0</a></p>\n",
+       "        <p><a href=https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=LIVRJilbGBeG-FkHDyiMNvSD7QsHlhAwn38t6wMbS4o&tc=7hcfKcxwWN5QezBa_VHG4kIM-mXxc0JdhzYJGKTLgi0&cc=FSz-8aCU4cep1dhVcACdwX_EQOcm7pVW80iCK3BvHM8>https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=LIVRJilbGBeG-FkHDyiMNvSD7QsHlhAwn38t6wMbS4o&tc=7hcfKcxwWN5QezBa_VHG4kIM-mXxc0JdhzYJGKTLgi0&cc=FSz-8aCU4cep1dhVcACdwX_EQOcm7pVW80iCK3BvHM8</a></p>\n",
        "        <p>The authorization workflow will generate a code, which you should paste in the box below.</p>\n",
        "        "
       ],
@@ -52,18 +52,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04342d7cb35a4662a4e4ebb9cf9c3fc5",
+       "model_id": "da082d5a98964b6d8af36fc8c065255f",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(VBox(children=(HBox(children=(Label(value='Controls', layout=Layout(flex='1')), Button(descript…"
+       "HBox(children=(VBox(children=(HTML(value='\\n<style>\\n@import url(\\'https://fonts.googleapis.com/css2?family=In…"
       ]
      },
      "metadata": {},
@@ -79,6 +87,33 @@
     "vibes = GeoVibes(\n",
     "    start_date=\"2024-01-01\", end_date=\"2025-01-01\", enable_ee=True, verbose=False\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Example adding CDL aquaculture\n",
+    "import ee\n",
+    "\n",
+    "ee.Initialize()\n",
+    "\n",
+    "cdl = (\n",
+    "    ee.ImageCollection(\"USDA/NASS/CDL\")\n",
+    "    .filterDate(\"2023-01-01\", \"2024-12-31\")\n",
+    "    .mosaic()\n",
+    "    .select(\"cropland\")\n",
+    ")\n",
+    "aquaculture = cdl.updateMask(cdl.neq(93))\n",
+    "vis_params = {\n",
+    "    \"min\": 0,\n",
+    "    \"max\": 93,\n",
+    "    \"palette\": [\"#000000\", \"#0000FF\"],  # Black to blue gradient for aquaculture\n",
+    "}\n",
+    "\n",
+    "vibes.add_ee_layer(aquaculture, {}, name=\"Aquaculture\", opacity=0.7)"
    ]
   },
   {
@@ -138,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +203,59 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": "## Example adding Cloud-Masked NDWI (Sentinel-2 with Cloud Score+)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "\n",
+    "ee.Initialize()\n",
+    "\n",
+    "# Cloud Score+ threshold (0-1, higher = more strict cloud masking)\n",
+    "CLOUD_THRESHOLD = 0.65\n",
+    "\n",
+    "# Date range for composite\n",
+    "start_date = \"2024-01-01\"\n",
+    "end_date = \"2024-12-31\"\n",
+    "\n",
+    "# Load Sentinel-2 SR and Cloud Score+ collections\n",
+    "s2_sr = ee.ImageCollection(\"COPERNICUS/S2_SR_HARMONIZED\")\n",
+    "cs_plus = ee.ImageCollection(\"GOOGLE/CLOUD_SCORE_PLUS/V1/S2_HARMONIZED\")\n",
+    "\n",
+    "# Join Cloud Score+ to S2 SR by system:index\n",
+    "s2_with_cs = s2_sr.linkCollection(cs_plus, [\"cs\"])\n",
+    "\n",
+    "# Filter by date and cloud score\n",
+    "filtered = s2_with_cs.filterDate(start_date, end_date).map(\n",
+    "    lambda img: img.updateMask(img.select(\"cs\").gte(CLOUD_THRESHOLD))\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Compute NDWI: (Green - NIR) / (Green + NIR)\n",
+    "# Sentinel-2: B3 = Green, B8 = NIR\n",
+    "def add_ndwi(img):\n",
+    "    ndwi = img.normalizedDifference([\"B3\", \"B8\"]).rename(\"NDWI\")\n",
+    "    return img.addBands(ndwi)\n",
+    "\n",
+    "\n",
+    "ndwi_collection = filtered.map(add_ndwi)\n",
+    "\n",
+    "# Create median composite\n",
+    "ndwi_composite = ndwi_collection.select(\"NDWI\").median()\n",
+    "\n",
+    "# Visualization: blue for water (positive NDWI), brown for land (negative)\n",
+    "ndwi_vis = {\n",
+    "    \"min\": -0.5,\n",
+    "    \"max\": 0.5,\n",
+    "    \"palette\": [\"#8B4513\", \"#D2B48C\", \"#FFFFFF\", \"#87CEEB\", \"#0000FF\"],\n",
+    "}\n",
+    "\n",
+    "vibes.add_ee_layer(ndwi_composite, ndwi_vis, name=\"NDWI (Cloud-masked)\", opacity=0.7)"
+   ]
   }
  ],
  "metadata": {

--- a/vibe_checker.ipynb
+++ b/vibe_checker.ipynb
@@ -52,21 +52,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da082d5a98964b6d8af36fc8c065255f",
+       "model_id": "0bf24af6de134a12943da96d55b7e93b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -91,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,18 +94,63 @@
     "\n",
     "cdl = (\n",
     "    ee.ImageCollection(\"USDA/NASS/CDL\")\n",
-    "    .filterDate(\"2023-01-01\", \"2024-12-31\")\n",
-    "    .mosaic()\n",
+    "    .filterDate(\"2023-01-01\", \"2023-12-31\")\n",
+    "    .first()\n",
     "    .select(\"cropland\")\n",
     ")\n",
-    "aquaculture = cdl.updateMask(cdl.neq(93))\n",
-    "vis_params = {\n",
+    "\n",
+    "\n",
+    "vibes.add_ee_layer(cdl, {}, name=\"CDL\", opacity=0.7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CDL Aquaculture + Water Mask with Morphological Closing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "\n",
+    "ee.Initialize()\n",
+    "\n",
+    "# Load CDL 2023\n",
+    "cdl = (\n",
+    "    ee.ImageCollection(\"USDA/NASS/CDL\")\n",
+    "    .filterDate(\"2023-01-01\", \"2023-12-31\")\n",
+    "    .first()\n",
+    "    .select(\"cropland\")\n",
+    ")\n",
+    "\n",
+    "# Binary mask: Aquaculture (92) OR Open Water (111)\n",
+    "water_mask = cdl.eq(92).Or(cdl.eq(111))\n",
+    "\n",
+    "# Morphological closing: dilation then erosion (3x3 kernel)\n",
+    "# This fills small gaps and smooths boundaries\n",
+    "closed_mask = (\n",
+    "    water_mask.focal_max(\n",
+    "        radius=1, kernelType=\"square\", units=\"pixels\"\n",
+    "    ).focal_min(radius=1, kernelType=\"square\", units=\"pixels\")  # dilation  # erosion\n",
+    ")\n",
+    "\n",
+    "# Visualization: show the mask\n",
+    "mask_vis = {\n",
     "    \"min\": 0,\n",
-    "    \"max\": 93,\n",
-    "    \"palette\": [\"#000000\", \"#0000FF\"],  # Black to blue gradient for aquaculture\n",
+    "    \"max\": 1,\n",
+    "    \"palette\": [\"#00000000\", \"#0066FF\"],  # transparent for 0, blue for 1\n",
     "}\n",
     "\n",
-    "vibes.add_ee_layer(aquaculture, {}, name=\"Aquaculture\", opacity=0.7)"
+    "# Add both layers to compare\n",
+    "vibes.add_ee_layer(water_mask.selfMask(), mask_vis, name=\"CDL Water (raw)\", opacity=0.7)\n",
+    "vibes.add_ee_layer(\n",
+    "    closed_mask.selfMask(), mask_vis, name=\"CDL Water (closed)\", opacity=0.7\n",
+    ")"
    ]
   },
   {
@@ -203,7 +240,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Example adding Cloud-Masked NDWI (Sentinel-2 with Cloud Score+)"
+   "source": [
+    "## Example adding Cloud-Masked NDWI (Sentinel-2 with Cloud Score+)"
+   ]
   },
   {
    "cell_type": "code",

--- a/vibe_checker.ipynb
+++ b/vibe_checker.ipynb
@@ -9,12 +9,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>To authorize access needed by Earth Engine, open the following\n",
+       "        URL in a web browser and follow the instructions:</p>\n",
+       "        <p><a href=https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=uqZS-obTBxnmg7z2DSMTBW4QKt-rU6H3qWB9ixCJf-4&tc=bSmOSLqACwNnJB19C-pQI7uCAfB6mzr3LTMy1m4DR7U&cc=XvXPiiDrDCyVg5wgPHGd-zVWtM1HR-WLYBLY6p7JWZ0>https://code.earthengine.google.com/client-auth?scopes=https%3A//www.googleapis.com/auth/earthengine%20https%3A//www.googleapis.com/auth/cloud-platform%20https%3A//www.googleapis.com/auth/drive%20https%3A//www.googleapis.com/auth/devstorage.full_control&request_id=uqZS-obTBxnmg7z2DSMTBW4QKt-rU6H3qWB9ixCJf-4&tc=bSmOSLqACwNnJB19C-pQI7uCAfB6mzr3LTMy1m4DR7U&cc=XvXPiiDrDCyVg5wgPHGd-zVWtM1HR-WLYBLY6p7JWZ0</a></p>\n",
+       "        <p>The authorization workflow will generate a code, which you should paste in the box below.</p>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Successfully saved authorization token.\n"
+     ]
+    }
+   ],
    "source": [
     "import ee\n",
-    "ee.Authenticate(force=True)\n"
+    "\n",
+    "ee.Authenticate(force=True)"
    ]
   },
   {
@@ -32,7 +58,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "80f3f1590e1d45e6ab3951874f6a4354",
+       "model_id": "04342d7cb35a4662a4e4ebb9cf9c3fc5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -51,11 +77,92 @@
     "from geovibes.ui import GeoVibes\n",
     "\n",
     "vibes = GeoVibes(\n",
-    "    start_date = '2024-01-01',\n",
-    "    end_date = '2025-01-01',\n",
-    "    enable_ee = False,\n",
-    "    verbose=False\n",
+    "    start_date=\"2024-01-01\", end_date=\"2025-01-01\", enable_ee=True, verbose=False\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example adding ESRI LULC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "\n",
+    "ee.Initialize()\n",
+    "ee.Authenticate()\n",
+    "lulc = ee.ImageCollection(\n",
+    "    \"projects/sat-io/open-datasets/landcover/ESRI_Global-LULC_10m_TS\"\n",
+    ")\n",
+    "\n",
+    "# Get 2024 mosaic and remap to sequential values\n",
+    "lulc_2024 = (\n",
+    "    lulc.filterDate(\"2024-01-01\", \"2024-12-31\")\n",
+    "    .mosaic()\n",
+    "    .remap([1, 2, 4, 5, 7, 8, 9, 10, 11], [1, 2, 3, 4, 5, 6, 7, 8, 9])\n",
+    ")\n",
+    "\n",
+    "# Visualization: Water, Trees, Flooded Veg, Crops, Built, Bare, Snow, Clouds, Rangeland\n",
+    "vis_params = {\n",
+    "    \"min\": 1,\n",
+    "    \"max\": 9,\n",
+    "    \"palette\": [\n",
+    "        \"#1A5BAB\",  # Water\n",
+    "        \"#358221\",  # Trees\n",
+    "        \"#87D19E\",  # Flooded Vegetation\n",
+    "        \"#FFDB5C\",  # Crops\n",
+    "        \"#ED022A\",  # Built Area\n",
+    "        \"#EDE9E4\",  # Bare Ground\n",
+    "        \"#F2FAFF\",  # Snow/Ice\n",
+    "        \"#C8C8C8\",  # Clouds\n",
+    "        \"#C6AD8D\",  # Rangeland\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "vibes.add_ee_layer(lulc_2024, vis_params, name=\"LULC 2024\", opacity=0.7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example adding SRTM Elevation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add elevation layer from SRTM dataset\n",
+    "dataset = ee.Image(\"USGS/SRTMGL1_003\")\n",
+    "elevation = dataset.select(\"elevation\")\n",
+    "\n",
+    "# Add elevation layer to the map\n",
+    "elevation_vis_params = {\n",
+    "    \"min\": 0,\n",
+    "    \"max\": 300,\n",
+    "    \"palette\": [\n",
+    "        \"#000080\",\n",
+    "        \"#0000FF\",\n",
+    "        \"#00FFFF\",\n",
+    "        \"#00FF00\",\n",
+    "        \"#FFFF00\",\n",
+    "        \"#FF8000\",\n",
+    "        \"#FF0000\",\n",
+    "        \"#800000\",\n",
+    "    ],  # Blue to red gradient for elevation\n",
+    "}\n",
+    "\n",
+    "vibes.add_ee_layer(elevation, elevation_vis_params, name=\"SRTM Elevation\", opacity=0.7)"
    ]
   },
   {
@@ -80,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Add Arbitrary Tile Layer Support with Layer Manager Widget

  ### Summary

  This PR adds the ability for users to programmatically add/remove tile layers (Earth Engine images or XYZ URLs) with opacity control. A floating layer manager
  widget provides an interactive UI for adjusting layer opacity and removing layers.

  ### Features

  **Tile Layer API**
  - `add_tile_layer(url, name, opacity, attribution)` - Add XYZ tile layers
  - `add_ee_layer(ee_image, vis_params, name, opacity)` - Add Earth Engine image layers
  - `remove_layer(name)` - Remove a layer by name
  - `set_layer_opacity(name, opacity)` - Adjust layer opacity (0.0-1.0)
  - `list_layers()` / `list_overlay_layers()` - List all overlay layer names
  - `clear_overlay_layers()` - Remove all overlay layers (called on app reset)

  **Layer Manager Widget**
  - Compact floating widget in top-left corner of map
  - Auto-shows when layers exist, auto-hides when empty
  - Each layer row displays: truncated name (9 chars max), opacity slider, remove button
  - Styled with ipyvuetify for consistent Material Design appearance
  - Fixed-width layout ensures proper alignment across all layer rows

  **Layer Ordering**
  - Overlay layers render above basemap but below GeoJSON layers (detections, search results)
  - Ensures user-added layers don't obscure important feature data

  ### Usage Example

  ```python
  # Add XYZ tile layer
  vibes.add_tile_layer(
      "https://tiles.example.com/{z}/{x}/{y}.png",
      name="Custom Tiles",
      opacity=0.7
  )

  # Add Earth Engine layer
  import ee
  ndvi = ee.ImageCollection("COPERNICUS/S2_SR").median().normalizedDifference(['B8', 'B4'])
  vibes.add_ee_layer(ndvi, {'min': 0, 'max': 1, 'palette': ['red', 'yellow', 'green']},
                     name="NDVI", opacity=0.5)

  # Adjust and manage
  vibes.set_layer_opacity("NDVI", 0.3)
  print(vibes.list_layers())  # ['Custom Tiles', 'NDVI']
  vibes.remove_layer("Custom Tiles")
```

  Test Plan

  - 25 unit tests covering all overlay layer functionality
  - Tests for edge cases: duplicate names, unknown layers, opacity clamping
  - Tests for layer manager widget show/hide behavior
  - Tests for name truncation (9 char limit)
  - Manual testing in notebook with ESRI LULC layer

  Files Changed

  | File                           | Changes                                   |
  |--------------------------------|-------------------------------------------|
  | geovibes/ui/map_manager.py     | Core layer management + ipyvuetify widget |
  | geovibes/ui/app.py             | Public API wrappers + reset handler       |
  | tests/test_map_manager_unit.py | 25 new unit tests                         |
  | pyproject.toml                 | Added ipyvuetify dependency               |

  🤖 Generated with https://claude.com/claude-code
